### PR TITLE
Fix: correct the game assets folder PATH

### DIFF
--- a/project/settings.toml
+++ b/project/settings.toml
@@ -38,4 +38,5 @@ includes    = [
 # Ursina assets dir
 ursina_dir  = "assets/ursina_assets"
 # Game assets dir
-game_dir    = "assets/ursina_assets"
+
+game_dir    = "assets/game_assets"


### PR DESCRIPTION
The original `game_dir` in `[assets]`, in `settings.toml` had the wrong PATH. fixed it to correctly be `assets/game_assets`.